### PR TITLE
Primeras correcciones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,47 +1,30 @@
-# Windows image file caches
-Thumbs.db
-ehthumbs.db
-
-# Folder config file
-Desktop.ini
-
-# Recycle Bin used on file shares
-$RECYCLE.BIN/
-
-# Windows Installer files
-*.cab
-*.msi
-*.msm
-*.msp
-
-# Windows shortcuts
-*.lnk
-
-# =========================
-# Operating System Files
-# =========================
-
-# OSX
-# =========================
-
-.DS_Store
-.AppleDouble
-.LSOverride
-
-# Thumbnails
-._*
-
-# Files that might appear in the root of a volume
-.DocumentRevisions-V100
-.fseventsd
-.Spotlight-V100
-.TemporaryItems
-.Trashes
-.VolumeIcon.icns
-
-# Directories potentially created on remote AFP share
-.AppleDB
-.AppleDesktop
-Network Trash Folder
-Temporary Items
-.apdisk
+syntax: glob
+*.resharper
+*.suo
+*.user
+*.pdb
+*.vspscc
+*.vsssccc
+*.scc
+*/_ReSharper*
+*/bin
+*/obj
+*/nunitbin
+*/_ReSharper.*
+bin
+obj
+nunitbin
+[Ww]orking
+TestResults
+AppPackages/*.resharperoptions
+*.db
+*.bak
+*_ReSharper*
+*.snk
+logs
+output
+TestResults
+.svn
+packages
+*.dat
+*.nupkg

--- a/ConsoleApplication1/MatrixRotation.csproj
+++ b/ConsoleApplication1/MatrixRotation.csproj
@@ -31,6 +31,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject>MatrixRotation.Solution</StartupObject>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/ConsoleApplication1/MatrixRotation.csproj.DotSettings
+++ b/ConsoleApplication1/MatrixRotation.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp50</s:String></wpf:ResourceDictionary>

--- a/ConsoleApplication1/Program.cs
+++ b/ConsoleApplication1/Program.cs
@@ -1,15 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.IO;
 using System.Collections;
-//Console.SetIn(new System.IO.StreamReader("D:\\Documentos\\Downloads\\input05.txt"));
+
 namespace MatrixRotation
 {
-
-    public class Solution
+    public static class Solution
     {
         internal static void Main()
         {
@@ -121,15 +117,14 @@ namespace MatrixRotation
                 throw new InvalidOperationException("Cannot rotate if Min(RowCount, ColumnCount) % 2 != 0");
             }
 
-
-
             if (numberOfRotations < 0)
             {
                 throw new ArgumentOutOfRangeException("numberOfRotations", "Cannot have negative rotations");
             }
-            int framework_Count = Math.Min(RowCount, ColumnCount) / 2;
-            Framework<T>[] frameworks = new Framework<T>[framework_Count];
-            for (int i = 0; i < framework_Count; i++)
+
+            int frameworkCount = Math.Min(RowCount, ColumnCount) / 2;
+            Framework<T>[] frameworks = new Framework<T>[frameworkCount];
+            for (int i = 0; i < frameworkCount; i++)
             {
                 frameworks[i] = Framework<T>.FromMatrix(this, i, numberOfRotations);
             }
@@ -137,43 +132,26 @@ namespace MatrixRotation
             return SetMatrixFromFrameworks(frameworks);
         }
 
-        public Matrix<T> SetMatrixFromFrameworks(Framework<T>[] frameworks)
+        private Matrix<T> SetMatrixFromFrameworks(IReadOnlyList<Framework<T>> frameworks)
         {
             var result = new Matrix<T>(RowCount, ColumnCount);
             PositionOnMatrixFramewokStyleEnumerator positionEnumerator = new PositionOnMatrixFramewokStyleEnumerator(RowCount, ColumnCount);
-            for (int i = 0; i < frameworks.Length; i++)
+            foreach (Framework<T> framework in frameworks)
             {
-                for (int j = 0; j < frameworks[i].ElementCount; j++)
+                for (int j = 0; j < framework.ElementCount; j++)
                 {
                     positionEnumerator.MoveNext();
-                    result[positionEnumerator.Current.Row, positionEnumerator.Current.Column] = frameworks[i][j];
-                }
-
-            }
-            return result;
-        }
-
-
-        public Matrix<T> Transform(Func<int, int, T> func)
-        {
-            var result = new Matrix<T>(RowCount, ColumnCount);
-
-            for (int row = 0; row < RowCount; row++)
-            {
-                for (int column = 0; column < ColumnCount; column++)
-                {
-                    result[row, column] = func(row, column);
+                    result[positionEnumerator.Current.Row, positionEnumerator.Current.Column] = framework[j];
                 }
             }
-
             return result;
         }
     }
 
     public class Framework<T>
     {
-        private T[] _values;
-        private int _startIndex;
+        private readonly T[] _values;
+        private readonly int _startIndex;
         private Framework(T[] values, int startIndex)
         {
 
@@ -188,7 +166,7 @@ namespace MatrixRotation
         {
             if (frameworkIndex >= Math.Min(matrix.RowCount, matrix.ColumnCount) / 2)
             {
-                throw new ArgumentOutOfRangeException("frameworkIndex must be lower than Math.Min(matrix.RowCount, matrix.ColumnCount) / 2");
+                throw new ArgumentOutOfRangeException("frameworkIndex", "frameworkIndex must be lower than Math.Min(matrix.RowCount, matrix.ColumnCount) / 2");
             }
 
             var enumerator = new PositionOnMatrixFramewokStyleEnumerator(matrix.RowCount, matrix.ColumnCount, frameworkIndex);
@@ -227,24 +205,26 @@ namespace MatrixRotation
         private PositionOnMatrix _position;
         private int? _frameworkIndex;
         private int _currentIndex;
-        private int _columnCount;
-        private int _rowCount;
+        private readonly int _columnCount;
+        private readonly int _rowCount;
 
         public PositionOnMatrixFramewokStyleEnumerator(int rowCount, int columnCount, int? frameworkIndex = null)
         {
             if (rowCount <= 0)
             {
-                throw new ArgumentOutOfRangeException("rowCount must be greater than 0");
+                throw new ArgumentOutOfRangeException("rowCount", "rowCount must be greater than 0");
             }
+
             if (columnCount <= 0)
             {
-                throw new ArgumentOutOfRangeException("columCount must be greater than 0");
-
+                throw new ArgumentOutOfRangeException("columnCount", "columnCount must be greater than 0");
             }
+
             if (frameworkIndex + 1 > Math.Min(rowCount, columnCount) / 2)
             {
-                throw new ArgumentOutOfRangeException("frameworwIndex must be lower than Math.Min(rowCount,columncount) / 2");
+                throw new ArgumentOutOfRangeException("frameworkIndex", "frameworwIndex must be lower than Math.Min(rowCount,columncount) / 2");
             }
+
             _currentIndex = -1;
             _position = null;
             _columnCount = columnCount;
@@ -260,10 +240,8 @@ namespace MatrixRotation
                 {
                     return (_columnCount - 2 * _frameworkIndex.Value) * 2 + (_rowCount - 2 * _frameworkIndex.Value - 2) * 2;
                 }
-                else
-                {
-                    return _columnCount * _rowCount;
-                }
+
+                return _columnCount * _rowCount;
             }
         }
 
@@ -403,16 +381,11 @@ namespace MatrixRotation
             {
                 throw new ArgumentOutOfRangeException("row", "Row must be lower than RowCount");
             }
-            RowCount = rowCount;
-            ColumnCount = columnCount;
 
             Row = row;
             Column = column;
 
         }
-        private int RowCount { get; set; }
-
-        private int ColumnCount { get; set; }
 
         public int Row { get; private set; }
 

--- a/MatrixRotationTest/UnitTest1.cs
+++ b/MatrixRotationTest/UnitTest1.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+
 namespace MatrixRotationTest
 {
     [TestClass]
@@ -21,12 +21,8 @@ namespace MatrixRotationTest
                 }
             }
 
-
-
             var listOfElements = new List<int>();
-
             var positionEnumerator = new MatrixRotation.PositionOnMatrixFramewokStyleEnumerator(matrix.RowCount, matrix.ColumnCount);
-
             while (positionEnumerator.MoveNext())
             {
 
@@ -34,7 +30,7 @@ namespace MatrixRotationTest
             }
 
             Assert.AreEqual(
-@"1 2 3 4 5 6 12 18 24 30 36 42 41 40 39 38 37 31 25 19 13 7 8 9 10 11 17 23 29 35 34 33 32 26 20 14 15 16 22 28 27 21", String.Join(" ", listOfElements));
+@"1 2 3 4 5 6 12 18 24 30 36 42 41 40 39 38 37 31 25 19 13 7 8 9 10 11 17 23 29 35 34 33 32 26 20 14 15 16 22 28 27 21", string.Join(" ", listOfElements));
         }
         [TestMethod]
         public void MatrixFrameworkStyleEnumeratorTestFrameworkSet()
@@ -50,10 +46,7 @@ namespace MatrixRotationTest
                 }
             }
 
-
-
             var listOfElements = new List<int>();
-
             var positionEnumerator = new MatrixRotation.PositionOnMatrixFramewokStyleEnumerator(matrix.RowCount, matrix.ColumnCount, 0);
 
             while (positionEnumerator.MoveNext())
@@ -63,18 +56,18 @@ namespace MatrixRotationTest
             }
 
             Assert.AreEqual(
-@"1 2 3 4 5 6 12 18 24 30 36 42 41 40 39 38 37 31 25 19 13 7", String.Join(" ", listOfElements));
+@"1 2 3 4 5 6 12 18 24 30 36 42 41 40 39 38 37 31 25 19 13 7", string.Join(" ", listOfElements));
 
             listOfElements.Clear();
             var positionEnumerator1 = new MatrixRotation.PositionOnMatrixFramewokStyleEnumerator(matrix.RowCount, matrix.ColumnCount, 1);
 
             while (positionEnumerator1.MoveNext())
             {
-
                 listOfElements.Add(matrix[positionEnumerator1.Current.Row, positionEnumerator1.Current.Column]);
             }
+
             Assert.AreEqual(
-@"8 9 10 11 17 23 29 35 34 33 32 26 20 14", String.Join(" ", listOfElements));
+@"8 9 10 11 17 23 29 35 34 33 32 26 20 14", string.Join(" ", listOfElements));
 
             listOfElements.Clear();
             var positionEnumerator2 = new MatrixRotation.PositionOnMatrixFramewokStyleEnumerator(matrix.RowCount, matrix.ColumnCount, 2);
@@ -86,7 +79,7 @@ namespace MatrixRotationTest
             }
 
             Assert.AreEqual(
-@"15 16 22 28 27 21", String.Join(" ", listOfElements));
+@"15 16 22 28 27 21", string.Join(" ", listOfElements));
         }
 
         [TestMethod]
@@ -103,6 +96,7 @@ namespace MatrixRotationTest
 5 6 10 16
 9 13 14 15");
         }
+
         [TestMethod]
         public void Test01()
         {
@@ -160,11 +154,12 @@ namespace MatrixRotationTest
 2 12 11 10 18 19 20 30
 1 9 17 25 26 27 28 29");
         }
-        private void Test(string input, string expectedOutput)
+
+        private static void Test(string input, string expectedOutput)
         {
             var reader = new StringReader(input);
             var writer = new StringWriter();
-            writer.NewLine = "\n";
+
             MatrixRotation.Problem.Solve(reader, writer);
             var actualOutput = writer.ToString().Trim();
 


### PR DESCRIPTION
Esto son sólo cambios de estilo, principalmente, y recomendaciones que conviene seguir por diversos motivos. Para muchas de estas cosas empleo el ReSharper (cuya licencia me pago religiosamente todos los años porque es la caña de España). Todavía no he entrado a "entender" tu solución y ver si se puede contar mejor. A primera vista tiene buena pinta, aunque estoy de acuerdo que el uso de `IEnumerator` crudos es pelín "sospechoso".
- Usings superfluos: quitarlos mejora la legibilidad, aclara mejor las dependencias de la clase.
- Comentarios con código: Sé que esa línea la tenías ahí para ejecutar un caso, pero aprovecho para recordar que nunca hay que dejar código comentado. Bórralo siempre. Si quieres recuperar código borrado, para eso está el control de versiones.
- Clases static: Si todos los métodos de una clase son static (Shared), haz la clase static para evitar que alguien la instancie por error.
- Líneas vacías extra: un estilo uniforme mejora la legibilidad, porque así el ojo sabe lo que esperar. El código es un poco como la escritura, no hay que poner separaciones salvo que quieras distinguirlas porque hacen cosas diferentes. Por ejemplo, también se recomienda poner una línea después de un bloque de código (if, for, switch). Pero no hay que poner más de una en ningún caso.
- Accesibilidad de miembros y clases: Todo debe ser lo más privado posible. Cuanto menos sepan tus clientes, menos lío podrán armar. Haz las clases internal (Friend) por defecto (de hecho, no poner nada equivale a internal). Los métodos y campos, privados salvo los que quieras exponer. Los campos readonly. Las propiedades, get-only.
- `IReadOnlyList`: Un interfaz que sacaron en la 4.5, implementado por todas las clases de colección típicas. Conviene usarlo siempre que no nos interese modificar la colección.
- Bucles `foreach`: Usa el foreach en lugar del for sobre índices (salvo que quieras el índice en sí para algo). Es más legible.
- Código muerto: Bórralo.
- `ArgumentOutOfRangeException` acepta como primer parámetro el nombre del parámetro fuera de rango. En C# 6 tienes el operador `nameof()` para obtener el nombre del parámetro sin usar cadenas literales.
- Ramas else redundantes: quitarlas aumenta la legibilidad, sobre todo si hay sólo dos ramas, al disminuir el nivel de indentación.
- Propiedades private `RowCount` y `ColumnCount`: yo las he eliminado por recomenación de ReSharper, pero la verdad es que no tengo problema con dejarlas.
- `String` vs `string`: está recomendado usar los alias para los tipos básicos. `string` mejor que `String`, `object` mejor que `Object`, `int`mejor que `Int32`, etc.
- Métodos static: Igual que las clases, los métodos conviene hacerlos static si no utilizan ningún miembro no static.
- Lo del `NewLine = "\n"` lo he quitado porque si no no me pasaban los tests.
